### PR TITLE
fix module so it works with viam server again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 main.spec
 .venv
 venv
+
+reload-*/

--- a/build.sh
+++ b/build.sh
@@ -15,4 +15,4 @@ if ! uv pip install pyinstaller -q; then
 fi
 
 uv run pyinstaller --onefile -p src src/main.py
-tar -czvf dist/archive.tar.gz ./dist/main
+tar -czvf dist/archive.tar.gz meta.json ./dist/main

--- a/meta.json
+++ b/meta.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://dl.viam.dev/module.schema.json",
-  "module_id": "viam:mcp300x-adc-sensor",
+  "module_id": "viam-labs:mcp300x-adc-sensor",
   "visibility": "public",
   "url": "https://github.com/viam-labs/mcp300x-adc-sensor",
   "description": "The module provides analog-to-digital conversion capabilities for MCP3002, MCP3004, and MCP3008 SPI ADCs for Raspberry Pi.",
   "models": [
     {
       "api": "rdk:component:sensor",
-      "model": "viam:mcp300x:sensor",
+      "model": "viam-labs:mcp300x:sensor",
       "short_description": "analog-to-digital conversion (ADC) capabilities for MCP3002, MCP3004, and MCP3008 chips using SPI",
       "markdown_link": "README.md#configure-your-mcp300x-adc-sensor"
     }

--- a/meta.json
+++ b/meta.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://dl.viam.dev/module.schema.json",
-  "module_id": "hazalmestci:mcp300x-adc-sensor",
+  "module_id": "viam:mcp300x-adc-sensor",
   "visibility": "public",
   "url": "https://github.com/viam-labs/mcp300x-adc-sensor",
   "description": "The module provides analog-to-digital conversion capabilities for MCP3002, MCP3004, and MCP3008 SPI ADCs for Raspberry Pi.",
   "models": [
     {
       "api": "rdk:component:sensor",
-      "model": "hazalmestci:sensor:mcp300x",
+      "model": "viam:mcp300x:sensor",
       "short_description": "analog-to-digital conversion (ADC) capabilities for MCP3002, MCP3004, and MCP3008 chips using SPI",
       "markdown_link": "README.md#configure-your-mcp300x-adc-sensor"
     }
@@ -18,8 +18,6 @@
     "build": "./build.sh",
     "setup": "./setup.sh",
     "path": "dist/archive.tar.gz",
-    "arch": [
-      "linux/arm64"
-    ]
+    "arch": ["linux/arm64"]
   }
 }

--- a/src/main.py
+++ b/src/main.py
@@ -1,24 +1,8 @@
 import asyncio
-
-from viam.components.sensor import Sensor
-from viam.resource.registry import Registry, ResourceCreatorRegistration
 from viam.module.module import Module
 from mcp300x import mcp3xxx
 
 
-async def main():
-    """This function creates and starts a new module, after adding all desired resources.
-    Resources must be pre-registered. For an example, see the `__init__.py` file.
-    """
-    Registry.register_resource_creator(
-        Sensor.SUBTYPE,
-        mcp3xxx.MODEL,
-        ResourceCreatorRegistration(mcp3xxx.new, mcp3xxx.validate),
-    )
-    module = Module.from_args()
-    module.add_model_from_registry(Sensor.SUBTYPE, mcp3xxx.MODEL)
-    await module.start()
-
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(Module.run_from_registry())

--- a/src/mcp300x.py
+++ b/src/mcp300x.py
@@ -20,7 +20,7 @@ LOGGER = getLogger(__name__)
 
 class mcp3xxx(Sensor, EasyResource):
     # Defines new model's colon-delimited-triplet
-    MODEL: ClassVar[Model] = Model(ModelFamily("viam", "mcp300x"), "sensor")
+    MODEL: ClassVar[Model] = Model(ModelFamily("viam-labs", "mcp300x"), "sensor")
 
     # Creates class parameters
     sensor_pin: int

--- a/src/mcp300x.py
+++ b/src/mcp300x.py
@@ -6,7 +6,7 @@ from viam.proto.app.robot import ComponentConfig
 from viam.proto.common import ResourceName
 from viam.resource.base import ResourceBase
 from viam.resource.types import Model, ModelFamily
-
+from viam.resource.easy_resource import EasyResource
 from viam.components.sensor import Sensor
 from viam.logging import getLogger
 
@@ -18,9 +18,9 @@ import adafruit_mcp3xxx.mcp3008 as MCP
 LOGGER = getLogger(__name__)
 
 
-class mcp3xxx(Sensor, Reconfigurable):
+class mcp3xxx(Sensor, EasyResource):
     # Defines new model's colon-delimited-triplet
-    MODEL: ClassVar[Model] = Model(ModelFamily("hazalmestci", "sensor"), "mcp300x")
+    MODEL: ClassVar[Model] = Model(ModelFamily("viam", "mcp300x"), "sensor")
 
     # Creates class parameters
     sensor_pin: int


### PR DESCRIPTION
this module is fundamentally broken and does not work with the latest RDK due to its use of SUBTYPE for sensors. it immediately throws errors when attempting to use it

also moves the module into the `viam` namespace (we should deprecate the one in hazal's org when module deprecation is available)